### PR TITLE
Avoid `provably unspendable` outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target/
 **/*.rs.bk
 
 .idea
+.vscode
 
 *.swp
 


### PR DESCRIPTION
**Description**

I made tests with RGB, and the PSBT always generate a 'provably unspendable' bitcoins after mining.

This situation occurred because the 'btc-cold construct' adds satoshis remaining in the taproot output, even setting the value in the change address. 

I changed the method to spend only the fee and add the value remaining at the change address. See example bellow:

![187035864-e0f98632-6cd8-4f5b-94d7-259a7c046238](https://user-images.githubusercontent.com/471380/189610206-a2639026-3baf-444e-be9e-9a3820afb24f.png)

The **nonstd** output is the outpoint used to anchor the RGB asset.

PS: I talked about this situation in another PR  (link [here](https://github.com/LNP-BP/nodes/pull/11#issuecomment-1229040213) and [here](https://github.com/LNP-BP/nodes/pull/11#issuecomment-1229210636))
