### PR TITLE
New descriptor type system capable of supporting tapret commitments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "psbt"
-version = "0.9.0-alpha.1"
+version = "0.9.0-alpha.2"
 dependencies = [
  "amplify",
  "bitcoin 0.29.2",

--- a/descriptors/src/descriptors2.rs
+++ b/descriptors/src/descriptors2.rs
@@ -1,0 +1,84 @@
+//! Experiments on new descriptor type system
+
+#![allow(unused)]
+
+use bitcoin::util::bip32::ChainCode;
+use bitcoin::XOnlyPublicKey;
+use bitcoin_hd::{DerivationSubpath, TerminalStep};
+use bitcoin_scripts::address::AddressPayload;
+use bitcoin_scripts::{LeafScript, TapNodeHash};
+use miniscript_crate::{Legacy, Miniscript, MiniscriptKey, Segwitv0, Tap};
+
+pub trait ScriptData: MiniscriptKey {
+    type Key;
+    type CompKey;
+    type XonlyKey;
+}
+
+pub trait OutputDescriptor {}
+
+pub enum Descr<D: ScriptData> {
+    Sh(ScriptDescr<D>),
+    Wsh(WScriptDescr<D>),
+    Pk(D),
+    Pkh(D),
+    Wpkh(D),
+
+    Combo(ComboDescr<D>),
+    Multi(MultiDescr<D, false>),
+    Sortedmulti(MultiDescr<D, true>),
+
+    Tr(TapKeyDescr<D>, TapNodeDescr<D>),
+
+    Raw(ScriptDescr<D>),
+    RawTr(XOnlyPublicKey),
+
+    Addr(AddressPayload),
+}
+
+pub enum ScriptDescr<D: ScriptData> {
+    Bitcoin(BitcoinScript<D>),
+    Miniscript(Miniscript<D, Legacy>),
+}
+
+pub enum WScriptDescr<D: ScriptData> {
+    Bitcoin(BitcoinScript<D>),
+    Miniscript(Miniscript<D, Segwitv0>),
+}
+
+pub struct ComboDescr<D: ScriptData>(Vec<D> /* at least 1 element, no repeated elements */);
+
+pub struct MultiDescr<D: ScriptData, const SORTED: bool> {
+    threshold: u8,
+    keys: Vec<D>, // at least 1 element, no repeated elements, ensure # >= threshold
+}
+
+pub enum TapKeyDescr<D: ScriptData> {
+    Unspend(ChainCode, DerivationSubpath<TerminalStep>),
+    Key(D),
+    MuSig(Vec<D>),
+}
+
+pub enum TapNodeDescr<D: ScriptData> {
+    TapScript(TapScript<D>),
+    TapMiniscript(Miniscript<D, Tap>),
+    RawLeaf(LeafScript),
+    RawNode(TapNodeHash),
+    Branch(Box<TapNodeDescr<D>>, Box<TapNodeDescr<D>>),
+}
+
+pub struct BitcoinScript<D: ScriptData> {
+    instructions: Vec<LegacyInstr<D>>,
+}
+
+pub struct TapScript<D: ScriptData> {
+    instructions: Vec<TapInstr<D>>,
+}
+
+pub enum LegacyInstr<D: ScriptData> {
+    Data(D), // enumerate opcodes
+}
+
+pub enum TapInstr<D: ScriptData> {
+    Data(D), // enumerate opcodes
+}

--- a/descriptors/src/descriptors2.rs
+++ b/descriptors/src/descriptors2.rs
@@ -2,9 +2,13 @@
 
 #![allow(unused)]
 
+use std::collections::HashMap;
+use std::hash::Hash;
+
+use amplify::Slice32;
 use bitcoin::util::bip32::ChainCode;
 use bitcoin::XOnlyPublicKey;
-use bitcoin_hd::{DerivationSubpath, TerminalStep};
+use bitcoin_hd::{DerivationSubpath, TerminalStep, UnhardenedIndex};
 use bitcoin_scripts::address::AddressPayload;
 use bitcoin_scripts::{LeafScript, TapNodeHash};
 use miniscript_crate::{Legacy, Miniscript, MiniscriptKey, Segwitv0, Tap};
@@ -13,11 +17,37 @@ pub trait ScriptData: MiniscriptKey {
     type Key;
     type CompKey;
     type XonlyKey;
+    type Definite;
 }
 
-pub trait OutputDescriptor {}
+pub trait Descriptor {
+    type Translated;
+    fn translate(&self) -> Self::Translated;
+}
 
-pub enum Descr<D: ScriptData> {
+pub struct AccDescr<D: ScriptData, K: ScriptData> {
+    keys: HashMap<D, K>,
+    descr: OutputDescr<D>,
+    terminal: Option<DerivationSubpath<TerminalStep>>,
+    tapret: HashMap<UnhardenedIndex, Slice32>,
+}
+
+impl<D: ScriptData, K: ScriptData> Descriptor for AccDescr<D, K> {
+    type Translated = K::Definite;
+    fn translate(&self) -> K::Definite { todo!() }
+}
+
+// Temporary type holder
+pub type AccId = Slice32;
+// Temporary type holder
+pub type AccStateId = Slice32;
+
+impl<D: ScriptData, K: ScriptData> AccDescr<D, K> {
+    pub fn id() -> AccId { todo!("commit to permanent parts") }
+    pub fn state_id() -> AccStateId { todo!("commit to variable parts") }
+}
+
+pub enum OutputDescr<D: ScriptData> {
     Sh(ScriptDescr<D>),
     Wsh(WScriptDescr<D>),
     Pk(D),

--- a/descriptors/src/descriptors2.rs
+++ b/descriptors/src/descriptors2.rs
@@ -25,14 +25,20 @@ pub trait Descriptor {
     fn translate(&self) -> Self::Translated;
 }
 
-pub struct AccDescr<D: ScriptData, K: ScriptData> {
+pub struct AccDescr<D: ScriptData, K: ScriptData, const TERM_LEN: usize> {
     keys: HashMap<D, K>,
     descr: OutputDescr<D>,
     terminal: Option<DerivationSubpath<TerminalStep>>,
-    tapret: HashMap<UnhardenedIndex, Slice32>,
+    tapret: Vec<TapretInfo<TERM_LEN>>,
 }
 
-impl<D: ScriptData, K: ScriptData> Descriptor for AccDescr<D, K> {
+pub struct TapretInfo<const TERM_LEN: usize> {
+    pub terminal: [UnhardenedIndex; TERM_LEN],
+    pub nonce: u8,
+    pub tweak: Slice32,
+}
+
+impl<D: ScriptData, K: ScriptData, const TERM_LEN: usize> Descriptor for AccDescr<D, K, TERM_LEN> {
     type Translated = K::Definite;
     fn translate(&self) -> K::Definite { todo!() }
 }
@@ -42,7 +48,7 @@ pub type AccId = Slice32;
 // Temporary type holder
 pub type AccStateId = Slice32;
 
-impl<D: ScriptData, K: ScriptData> AccDescr<D, K> {
+impl<D: ScriptData, K: ScriptData, const TERM_LEN: usize> AccDescr<D, K, TERM_LEN> {
     pub fn id() -> AccId { todo!("commit to permanent parts") }
     pub fn state_id() -> AccStateId { todo!("commit to variable parts") }
 }

--- a/descriptors/src/lib.rs
+++ b/descriptors/src/lib.rs
@@ -33,6 +33,7 @@ extern crate serde_crate as serde;
 mod deduction;
 pub mod derive;
 mod descriptor;
+pub mod descriptors2;
 mod input;
 #[cfg(feature = "miniscript")]
 mod templates;


### PR DESCRIPTION
Some time ago Bitcoin Core wallet introduced **[output descriptors](https://gist.github.com/sipa/06c5c844df155d4e5044c2c8cac9c05e)**, which are the way to _define a collection of bitcoin transaction output managed by certain wallet_. 

These descriptors gained traction, since they solved a couple of problems:
* standard way of declaring multisig wallets with extended keys
* interoperability with other wallet software (wallet export-import)
* backups of the complex wallets.

Descriptors were extended with a **miniscript** - a language which can be used in _some_ parts of the descriptors to deterministically define a complex bitcoin scripts and satisfy them in an automatic way. While miniscript has unlocked wallets beyond simple multisigs (but also having timelocks etc) and for sure has provided utility of automatic satisfaction for complex scripts (much better PSBT signers for instance), it doesn't cover all of the cases required:
* some parts of descriptors can't be represented with miniscript (for instance key-path spending conditions in taproot, future leafscript versions etc);
* it doesn't work well with descriptors for all existing forms of bitcoin scripts (for instance, all existing lightning network standard scripts are not covered);
* it has proven to be still highly unstable with a frequent breaking changes introduced into the instruction set and their compillation.

Taproot softfork - and upcoming introduction of MuSig2 standard have also put a requirement to extend descriptors further. Right now there is an ongoing work with [a proposal by P. Wuille](https://gist.github.com/sipa/06c5c844df155d4e5044c2c8cac9c05e), which is [gradually get implemented in Bitcoin Core](https://github.com/bitcoin/bitcoin/pull/23480).

RGB puts a requirement for another extension - support for tapret commitments, which has not being addressed yet even as a proposal.

There is only a single implementation of descriptor functionality in rust bitcoin world, which is a part of rust-miniscript library, tightly related and build on top of miniscript itself. It has a significant drawbacks which prevent its use in LNP/BP and RGB wallets as of today and tomorrow:
* It doesn't support lightning network;
* It doesn't support unspendable and musig fragments for taproot;
* The API being constantly refactored with each major release, requiring >20 hr of work to update dependent code in LNP/BP repositories;
* The API is very inefficient and clunky, with a lot of unnecessary errors, panics etc caused by a poor design of how conditions like "uncompressed public key in segwit context" are handled at the level of the core generics.

This PR aims at introducing a new descriptors API supporting both miniscript and non-miniscript bitcoin scripts, future Taproot extensions and Tapret commitments.