### PR TITLE
add password options + fix password prompts

### DIFF
--- a/src/bin/btc-hot.rs
+++ b/src/bin/btc-hot.rs
@@ -170,7 +170,7 @@ fn get_password(password_arg: Option<String>, prompt: &str) -> Result<String, st
     if let Some(pass) = password_arg.clone() {
         Ok(pass)
     } else {
-        print!("{prompt}: ");
+        eprint!("{prompt}: ");
         std::io::stdout().flush().unwrap();
         rpassword::read_password()
     }


### PR DESCRIPTION
This fixes password prompts, which were did not appear on the console, and adds options for `btc-hot` to provide passwords directly from the command line (for unattended usage).